### PR TITLE
Fix broken link

### DIFF
--- a/chapters/what.md
+++ b/chapters/what.md
@@ -66,7 +66,7 @@ ocaml --version
 
 堀本さんはこれを受けて、誤記を訂正するプルリクエストとして以下のようなフィードバックを行いました。
 
-* https://github.com/ocaml/ocaml.org/pull/1065
+* https://github.com/ocaml/v2.ocaml.org/pull/1065
 
 ```text {num=false}
 ■タイトル


### PR DESCRIPTION
Dear piroor.

Opening the following link will result in a 404 error.

- https://github.com/ocaml/ocaml.org/pull/1065

Probably, the OCaml document was moved from ocaml.org to v2.ocaml.org.
