### PR TITLE
Fix error installing bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ $ sudo apt install texlive-binaries texlive-lang-japanese \
                    texlive-latex-recommended texlive-latex-extra \
                    imagemagick \
                    ruby-dev build-essential
-$ sudo gem install bundler unicode-display_width
+$ sudo gem install bundler -v 2.3.26
+$ sudo gem install unicode-display_width
 ```
 
 npmのインストールも必要。


### PR DESCRIPTION
Dear piroor.

I tried to build the e-book, but error installing bundler.

Steps to reproduce
---

1. Install Ubuntu 18.04 LTS on WSL 1 on Windows 10
    ```cmd.exe
    wsl.exe --install --distribution Ubuntu-18.04
    ```
2. Enter new UNIX username
3. Enter new UNIX password
4. Retype new UNIX password
5. Upgrade packages
    ```bash
    $ sudo apt update && sudo apt upgrade -y
    ```
6. Install required packages
    ```bash
    $ sudo apt install texlive-binaries texlive-lang-japanese \
                       texlive-latex-recommended texlive-latex-extra \
                       imagemagick \
                       ruby-dev build-essential
    ```
7. Install required gems
    ```bash
    $ sudo gem install bundler unicode-display_width
    ```

Expected result
---

Successfully installed bundler and unicode-display_width.

Actual result
---

Error installing bundler with the below command.

```bash
$ sudo gem install bundler unicode-display_width
Fetching: bundler-2.4.7.gem (100%)
ERROR:  Error installing bundler:
        The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
        bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
Fetching: unicode-display_width-2.4.2.gem (100%)
Successfully installed unicode-display_width-2.4.2
Parsing documentation for unicode-display_width-2.4.2
Installing ri documentation for unicode-display_width-2.4.2
Done installing documentation for unicode-display_width after 0 seconds
1 gem installed
```
