### PR TITLE
Fix error running node18

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,30 @@ $ sudo gem install unicode-display_width
 ```
 
 npmのインストールも必要。
-aptで入るバージョンは古いので、[Ubuntuに最新のNode.jsを難なくインストールする - Qiita](https://qiita.com/seibe/items/36cef7df85fe2cefa3ea)などで紹介されているように、`n`を使って最新安定版のnpmを使える状態にする。
+aptで入るバージョンは古いので、[Ubuntuに最新のNode.jsを難なくインストールする - Qiita](https://qiita.com/seibe/items/36cef7df85fe2cefa3ea)などで紹介されているように、`n`を使ってnpmを使える状態にする。
+最新安定版（Node.js 18 LTS）では実行時にエラーとなるため、安定版（Node.js 16 LTS）を使う。
+
+<!--
+```bash
+$ sudo apt install -y nodejs npm
+$ sudo npm install n -g
+$ sudo n stable
+$ sudo apt purge -y nodejs npm
+$ exec $SHELL -l
+$ node -v
+node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
+```
+-->
+
+```bash
+$ sudo apt install -y nodejs npm
+$ sudo npm install n -g
+$ sudo n 16
+$ sudo apt purge -y nodejs npm
+$ exec $SHELL -l
+$ node -v
+v16.19.1
+```
 
 PDFtkをインストールする。
 


### PR DESCRIPTION
Dear piroor.

First([#39](https://github.com/oss-gate/first-feedback-guidebook/pull/39#issuecomment-1438356115)), I tried to build the e-book on Ubuntu 18.04 LTS, but error running Node.js 18.04 LTS.

Steps to reproduce
---

1. Install Ubuntu 18.04 LTS on WSL 1 on Windows 10
    ```cmd.exe
    wsl.exe --install --distribution Ubuntu-18.04
    ```
2. Enter new UNIX username
3. Enter new UNIX password
4. Retype new UNIX password
5. Upgrade packages
    ```bash
    $ sudo apt update && sudo apt upgrade -y
    ```
6. Install required packages
    ```bash
    $ sudo apt install texlive-binaries texlive-lang-japanese \
                       texlive-latex-recommended texlive-latex-extra \
                       imagemagick \
                       ruby-dev build-essential
    ```
7. Install required gems
    ```bash
    $ sudo gem install bundler -v 2.3.26
    $ sudo gem install unicode-display_width
    ```
8. Install Node.js
    ```bash
    $ sudo apt install -y nodejs npm
    $ sudo npm install n -g
    $ sudo n stable
    $ sudo apt purge -y nodejs npm
    $ exec $SHELL -l
    $ node -v
    ```

Expected result
---

Successfully show Node.js version.

Actual result
---

Error running Node.js with the below command.

```bash
$ node -v
node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by node)
```
