### PR TITLE
最新環境でビルド手順が通るように、各パッケージへのパッチ追加で対応して記載内容を変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,31 +100,31 @@ OSS Gateワークショップ参加者の方からよく寄せられる疑問へ
 
 ### 電子書籍用データ・印刷用データのビルド手順
 
-Ubuntu 18.04LTS on WSL on Windows 10で動作を確認した。
+Ubuntu 20.04LTS on WSL on Windows 11で動作を確認した。
 
-必要なパッケージをインストールする。
+必要なパッケージをインストールする。PDFtk、npmも必要。
 
 ```bash
-$ sudo apt install texlive-binaries texlive-lang-japanese \
-                   texlive-latex-recommended texlive-latex-extra \
-                   imagemagick \
-                   ruby-dev build-essential
+$ sudo apt -y install texlive-binaries texlive-lang-japanese \
+                      texlive-latex-recommended texlive-latex-extra \
+                      imagemagick \
+                      ruby-dev build-essential pdftk-java nodejs npm
 $ sudo gem install bundler -v 2.3.26
 $ sudo gem install unicode-display_width
+$ sudo npm install n -g
+$ sudo n stable
+$ sudo apt purge -y nodejs npm
+$ sudo apt -y autoremove
+$ exec $SHELL -l
 ```
 
-npmのインストールも必要。
-aptで入るバージョンは古いので、[Ubuntuに最新のNode.jsを難なくインストールする - Qiita](https://qiita.com/seibe/items/36cef7df85fe2cefa3ea)などで紹介されているように、`n`を使って最新安定版のnpmを使える状態にする。
-
-PDFtkをインストールする。
+ソースをクローンする。この後の手順で必要になるパッチが含まれている。
 
 ```bash
-$ sudo add-apt-repository ppa:malteworld/ppa
-$ sudo apt update
-$ sudo apt install pdftk
+$ git clone https://github.com/oss-gate/first-feedback-guidebooks.git
 ```
 
-Re:VIEWをインストールする。リリース版（4.0.0）ではビルドに失敗したため、masterを使う。
+Re:VIEWをインストールする。v4.0.0にパッチを当て使う。
 
 <!--
 ```bash
@@ -135,13 +135,15 @@ $ sudo gem install review
 ```bash
 $ git clone https://github.com/kmuto/review.git
 $ cd review
+$ git checkout v4.0.0 -b v4.0.0
+$ cat ../first-feedback-guidebook/patches/review.patch | patch -p1
 $ bundle install --path vendor/bundle
 $ rake build
 $ sudo gem install pkg/review-*.gem
 $ cd ..
 ```
 
-easybooksをインストールする。リリース版ではビルドに失敗し、且つ、要件を満たさないため、改造版を使う。
+easybooksをインストールする。リリース版ではビルドに失敗し、且つ、要件を満たさないため、改造版にパッチを当て使う。
 
 <!--
 ```bash
@@ -153,6 +155,7 @@ $ sudo npm install -g easybooks
 $ git clone https://github.com/piroor/easybooks.git
 $ cd easybooks
 $ git checkout enhanced
+$ cat ../first-feedback-guidebook/patches/easybooks.patch | patch -p1
 $ npm install
 $ npm run build
 $ sudo npm install -g .
@@ -162,7 +165,6 @@ $ cd ..
 以上で準備完了。makeするとPDFとEPUBの両方が作られ、distディレクトリ配下に出力される。
 
 ```bash
-$ git clone https://github.com/oss-gate/first-feedback-guidebook.git
 $ cd first-feedback-guidebook
 $ make
 ```

--- a/build-book.sh
+++ b/build-book.sh
@@ -10,7 +10,7 @@ texdocumentclass_ebook=media=ebook,paperwidth=152mm,paperheight=227mm,head_space
 texdocumentclass_print=media=print,paper=b5,head_space=30mm
 
 cover_pdf='"titlepage": true,'
-cover_epub='"coverimage":"images/tobira-ebook-01.png", "titlepage": false,'
+cover_epub='"coverimage":"tobira-ebook-01.png", "titlepage": false,'
 
 printing='"prt": "日光企画",'
 

--- a/first-feedback-guidebook.json
+++ b/first-feedback-guidebook.json
@@ -15,6 +15,9 @@
   "toclevel": 2,
   "secnolevel": 2,
   "review_version": 4.0,
+  "epubmaker": {
+    "image_maxpixels": 30000000
+  },
   "texstyle": [
     "reviewmacro",
     "em-bold"

--- a/patches/easybooks.patch
+++ b/patches/easybooks.patch
@@ -1,0 +1,12 @@
+diff --git a/package.json b/package.json
+index 0854214..317560d 100644
+--- a/package.json
++++ b/package.json
+@@ -41,6 +41,7 @@
+     "@babel/core": "^7.7.7",
+     "@babel/preset-env": "^7.7.7",
+     "@babel/preset-typescript": "^7.7.7",
++    "@types/babel__traverse": "7.14.2",
+     "@types/jest": "^24.0.25",
+     "@types/js-yaml": "3.12.1",
+     "@types/jszip": "^3.1.6",

--- a/patches/review.patch
+++ b/patches/review.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/review/epubmaker.rb b/lib/review/epubmaker.rb
+index e6b55149..0f08ee70 100644
+--- a/lib/review/epubmaker.rb
++++ b/lib/review/epubmaker.rb
+@@ -429,6 +429,7 @@ module ReVIEW
+     def detect_properties(path)
+       properties = []
+       File.open(path) do |f|
++        REXML::Document.entity_expansion_text_limit=3276800
+         doc = REXML::Document.new(f)
+         if REXML::XPath.first(doc, '//m:math', 'm' => 'http://www.w3.org/1998/Math/MathML')
+           properties << 'mathml'


### PR DESCRIPTION
- Ubuntu 18.04LTSでは最新のnpmが使えず(node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found)、pdftkのインストールも困難になったため、 Ubuntu 20.04LTSを対象に変更。
- npmインストール手順を(外部参照せず)組み込む。
- Re:Viewのmasterはメジャーバージョンアップされたため、v4.0.0をcheckoutする手順を追加。
- Rubyのバージョンアップにより「review-epubmaker: entity expansion has grown too large」が発生しEPUBビルドが失敗するため、Re:Viewへのパッチで対応。
- @types/babel__traverse最新版がTypeScript v3.7.4ではビルドエラーになるため、 easybooksへのパッチで対応。
- epubのcoverimageパスがずれnot foundになるため修正。
- review-epubmakerにおいて大サイズ画像使用時にWARNが出るため修正。